### PR TITLE
(FM-8091) fix build

### DIFF
--- a/configs/components/pe-ace-services.rb
+++ b/configs/components/pe-ace-services.rb
@@ -3,6 +3,7 @@ component "pe-ace-services" do |pkg, settings, platform|
   pkg.environment "GEM_PATH", '/opt/puppetlabs/server/apps/ace-server/lib/ruby:/opt/puppetlabs/server/apps/bolt-server/lib/ruby:/opt/puppetlabs/puppet/lib/ruby/gems/2.5.0:/opt/puppetlabs/puppet/lib/ruby/vendor_gems'
   pkg.environment "PATH", "#{settings[:bindir]}:$$PATH"
   pkg.load_from_json('configs/components/ace.json')
+  pkg.build_requires 'puppet-agent'
   pkg.build_requires 'pe-bolt-server'
 
   pkg.build do


### PR DESCRIPTION
Seems like pe-bolt-server has dropped its puppet-agent dependency.

Re-add here.