### PR TITLE
(PE-26576) adding in redhatfips for 2019.2.x

### DIFF
--- a/configs/platforms/redhatfips-7-x86_64.rb
+++ b/configs/platforms/redhatfips-7-x86_64.rb
@@ -1,0 +1,13 @@
+peversion = IO.read('peversion').strip
+platform "redhatfips-7-x86_64" do |plat|
+  plat.servicedir "/usr/lib/systemd/system"
+  plat.defaultdir "/etc/sysconfig"
+  plat.servicetype "systemd"
+
+  plat.provision_with "rpm --import http://yum.puppetlabs.com/RPM-GPG-KEY-puppetlabs"
+  plat.add_build_repository "http://enterprise.delivery.puppetlabs.net/#{peversion}/repos/#{plat.get_name}/#{plat.get_name}.repo"
+  plat.add_build_repository "http://pl-build-tools.delivery.puppetlabs.net/yum/pl-build-tools-release-el-7.noarch.rpm"
+  plat.provision_with "yum install --assumeyes autoconf automake rsync gcc createrepo make rpmdevtools rpm-libs yum-utils rpm-sign libtool git"
+  plat.install_build_dependencies_with "yum install --assumeyes"
+  plat.vmpooler_template "redhat-fips-7-x86_64"
+end

--- a/ext/build_defaults.yaml
+++ b/ext/build_defaults.yaml
@@ -8,7 +8,7 @@ repo_name: 'puppet5'
 nonfinal_repo_name: 'puppet5-nightly'
 build_tar: FALSE
 deb_targets: 'xenial-amd64 bionic-amd64'
-rpm_targets: 'el-6-x86_64 el-7-x86_64 el-8-x86_64 sles-12-x86_64'
+rpm_targets: 'el-6-x86_64 el-7-x86_64 el-8-x86_64 redhatfips-7-x86_64 sles-12-x86_64'
 osx_signing_cert: "Developer ID Installer: PUPPET LABS, INC. (VKGLGN2B6Y)"
 osx_signing_keychain: "/Users/jenkins/Library/Keychains/signing.keychain"
 osx_signing_server: 'osx-signer.delivery.puppetlabs.net'


### PR DESCRIPTION
This is currently not going to build until the pe-bolt-server adds builds for fips. Opening the PR anyway to verify it is valid with RE.