### PR TITLE
(maint) adding the net-ssh-telnet gem as a component

### DIFF
--- a/configs/components/rubygem-net-ssh-telnet.rb
+++ b/configs/components/rubygem-net-ssh-telnet.rb
@@ -1,0 +1,5 @@
+component "rubygem-net-ssh-telnet" do |pkg, settings, platform|
+  pkg.version "0.2.1"
+  pkg.md5sum "ba525a9f854cd22a6dd1cf0c8e6bd411"
+  instance_eval File.read('configs/components/_base-rubygem.rb')
+end

--- a/configs/projects/pe-ace-server.rb
+++ b/configs/projects/pe-ace-server.rb
@@ -39,6 +39,7 @@ project "pe-ace-server" do |proj|
             is_system: true)
 
   proj.component 'rubygem-puma'
+  proj.component 'rubygem-net-ssh-telnet'
   proj.component 'pe-ace-services'
 
   proj.directory proj.prefix


### PR DESCRIPTION
The `net-ssh-telnet` gem is used within networking modules.

As ACE will be handling the execution of networking modules we need to ensure that this gem will be available without user interaction, i.e. we should not expect the user to install this gem.