### PR TITLE
(PE-27107) Add openssl-devel to fips builds

### DIFF
--- a/configs/platforms/redhatfips-7-x86_64.rb
+++ b/configs/platforms/redhatfips-7-x86_64.rb
@@ -7,7 +7,24 @@ platform "redhatfips-7-x86_64" do |plat|
   plat.provision_with "rpm --import http://yum.puppetlabs.com/RPM-GPG-KEY-puppetlabs"
   plat.add_build_repository "http://enterprise.delivery.puppetlabs.net/#{peversion}/repos/#{plat.get_name}/#{plat.get_name}.repo"
   plat.add_build_repository "http://pl-build-tools.delivery.puppetlabs.net/yum/pl-build-tools-release-el-7.noarch.rpm"
-  plat.provision_with "yum install --assumeyes autoconf automake rsync gcc createrepo make rpmdevtools rpm-libs yum-utils rpm-sign libtool git"
+
+  packages = [
+    "autoconf",
+    "automake",
+    "createrepo",
+    "gcc",
+    "git",
+    "libtool",
+    "make",
+    "openssl-devel",
+    "rpmdevtools",
+    "rsync",
+    "rpm-build",
+    "rpm-libs",
+    "rpm-sign",
+    "yum-utils",
+  ]
+  plat.provision_with "yum install -y --nogpgcheck #{packages.join(' ')}"
   plat.install_build_dependencies_with "yum install --assumeyes"
   plat.vmpooler_template "redhat-fips-7-x86_64"
 end


### PR DESCRIPTION
This commit adds the openssl-devel package to FIPS builds so that puma
is able to build against system OpenSSL to allow the gem to be
FIPS-compliant.

This is based on the changes in this PR: https://github.com/puppetlabs/pe-bolt-vanagon/pull/12