### PR TITLE
(packaging) Ship new puma

### DIFF
--- a/configs/components/rubygem-puma.rb
+++ b/configs/components/rubygem-puma.rb
@@ -1,5 +1,5 @@
 component "rubygem-puma" do |pkg, settings, platform|
-  pkg.version "3.12.1"
-  pkg.md5sum "8349b8ff0f55e0a8d5833580e8139c3c"
+  pkg.version "4.3.1"
+  pkg.md5sum "2261b2bfffffc47aa7674908dbad7bad"
   instance_eval File.read('configs/components/_base-rubygem.rb')
 end


### PR DESCRIPTION
This commit updates puma to the 4.x series to match bolt-server. It is somewhat unclear to my why we have to ship the puma gem in both the bolt-server and ace-server packages, though I can see places where we depend on it being where it is currently https://github.com/puppetlabs/ace-vanagon/blob/799d25219e868eaf7b7736795eed9e0ee88219b5/resources/systemd/pe-ace-server.service#L11