### PR TITLE
(packaging) Add new nio4r gem for puma

### DIFF
--- a/configs/components/rubygem-nio4r.rb
+++ b/configs/components/rubygem-nio4r.rb
@@ -1,0 +1,5 @@
+component "rubygem-nio4r" do |pkg, settings, platform|
+  pkg.version "2.5.2"
+  pkg.md5sum "fdbe3fc810a77c0182854c0e9b889962"
+  instance_eval File.read('configs/components/_base-rubygem.rb')
+end

--- a/configs/projects/pe-ace-server.rb
+++ b/configs/projects/pe-ace-server.rb
@@ -38,6 +38,7 @@ project "pe-ace-server" do |proj|
             homedir: "#{proj.homedir}",
             is_system: true)
 
+  proj.component 'rubygem-nio4r'
   proj.component 'rubygem-puma'
   proj.component 'rubygem-net-ssh-telnet'
   proj.component 'pe-ace-services'


### PR DESCRIPTION
The puma 4.x series pulls in dependency on nio4r. This commit adds the gem to the ace-vanagon packaging project.