### PR TITLE
(PE-30632) Set GEM_HOME in addition to GEM_PATH

### DIFF
--- a/resources/redhat/pe-ace-server.init
+++ b/resources/redhat/pe-ace-server.init
@@ -18,6 +18,7 @@ umask 027
 prefix='/opt/puppetlabs/server/apps/ace-server'
 bolt_server='/opt/puppetlabs/server/apps/bolt-server'
 export GEM_PATH="${prefix}/lib/ruby:${bolt_server}/lib/ruby"
+export GEM_HOME="${prefix}/lib/ruby:${bolt_server}/lib/ruby"
 exec="${prefix}/bin/puma"
 prog="ace-server"
 desc="PE ACE Server"

--- a/resources/systemd/pe-ace-server.service
+++ b/resources/systemd/pe-ace-server.service
@@ -8,6 +8,7 @@ Group=pe-ace-server
 EnvironmentFile=-/etc/sysconfig/pe-ace-server-service
 EnvironmentFile=-/etc/default/pe-ace-server-service
 Environment=GEM_PATH=/opt/puppetlabs/server/apps/ace-server/lib/ruby:/opt/puppetlabs/server/apps/bolt-server/lib/ruby
+Environment=GEM_HOME=/opt/puppetlabs/server/apps/ace-server/lib/ruby:/opt/puppetlabs/server/apps/bolt-server/lib/ruby
 ExecStart=/opt/puppetlabs/server/apps/ace-server/bin/puma -C /opt/puppetlabs/server/apps/ace-server/config/transport_tasks_config.rb -e production
 Restart=always
 #set default privileges to -rw-r-----


### PR DESCRIPTION
Previously the default value for GEM_HOME caused us to load puppet agent
puppet when ace-server starts. This commit overrides it to isolate gem
environment and prevent loading the puppet code that ships with the agent.