### PR TITLE
(RE-13449) Remove old gpg key from build_defaults.yaml

### DIFF
--- a/ext/build_defaults.yaml
+++ b/ext/build_defaults.yaml
@@ -1,7 +1,6 @@
 ---
 project: 'puppet-ace'
 gpg_name: 'info@puppetlabs.com'
-gpg_key: '7F438280EF8D349F'
 sign_tar: FALSE
 vanagon_project: TRUE
 repo_name: 'puppet5'


### PR DESCRIPTION
The `gpg_key` setting is overridden by the one in `build-data`. Remove the
local soon-to-be-expired GPG key from the local repo for clarity and
cleanliness.